### PR TITLE
SurfaceFlinger: allow force fallback to Light HAL for set brightness

### DIFF
--- a/services/surfaceflinger/SurfaceFlinger.cpp
+++ b/services/surfaceflinger/SurfaceFlinger.cpp
@@ -438,6 +438,9 @@ SurfaceFlinger::SurfaceFlinger(Factory& factory) : SurfaceFlinger(factory, SkipI
     property_get("debug.sf.disable_client_composition_cache", value, "0");
     mDisableClientCompositionCache = atoi(value);
 
+    property_get("ro.sf.force_light_brightness", value, "0");
+    mForceLightBrightness = atoi(value);
+
     // We should be reading 'persist.sys.sf.color_saturation' here
     // but since /data may be encrypted, we need to wait until after vold
     // comes online to attempt to read the property. The property is
@@ -1515,6 +1518,10 @@ status_t SurfaceFlinger::getDisplayBrightnessSupport(const sp<IBinder>& displayT
     const auto displayId = getPhysicalDisplayIdLocked(displayToken);
     if (!displayId) {
         return NAME_NOT_FOUND;
+    }
+    if (mForceLightBrightness) {
+        *outSupport = false;
+        return NO_ERROR;
     }
     *outSupport =
             getHwComposer().hasDisplayCapability(*displayId, hal::DisplayCapability::BRIGHTNESS);

--- a/services/surfaceflinger/SurfaceFlinger.h
+++ b/services/surfaceflinger/SurfaceFlinger.h
@@ -1249,6 +1249,7 @@ private:
     bool mSetActiveConfigPending = false;
 
     bool mLumaSampling = true;
+    bool mForceLightBrightness = false;
     sp<RegionSamplingThread> mRegionSamplingThread;
     ui::DisplayPrimaries mInternalDisplayPrimaries;
 


### PR DESCRIPTION
In commit "Moved brightness from Lights to SF.", it becomes
possible to implement brightness functions in HW Composer HAL
instead of Light HAL.

However, some vendors implement this in a non-conforming way
which leads to undesired results.

Re-implementing HW Composer HAL is extremely hard if not impossible
for some devices while Light HAL can be easily re-implemented. Thus,
improper implementations of brightness functions cannot be overridden
easily if they are in HW Composer HAL.

This change adds a property "ro.sf.force_light_brightness" to allow
force fallback to Light HAL for brightness functions.

Change-Id: I063de09e7ebbd75b4dc36ca0ae9914ee408e7447
Signed-off-by: Jesse Chan <jc@lineageos.org>