### PR TITLE
Mark accelerometer/input as sensor exclusively because there are ABS …

### DIFF
--- a/services/inputflinger/reader/EventHub.cpp
+++ b/services/inputflinger/reader/EventHub.cpp
@@ -2041,7 +2041,13 @@ void EventHub::openDeviceLocked(const std::string& devicePath) {
 
     // Check whether this device is an accelerometer.
     if (device->propBitmask.test(INPUT_PROP_ACCELEROMETER)) {
-        device->classes |= InputDeviceClass::SENSOR;
+        bool hasAxis = false;
+        for (int i = 0; i <= ABS_MAX; i++) {
+            if (device->absBitmask.test(i)) hasAxis = true;
+        }
+        if(hasAxis) {
+            device->classes |= InputDeviceClass::SENSOR;
+        }
     }
 
     // Check whether this device has switches.


### PR DESCRIPTION
…axis

On some legacy devices, the input device reports the power button/vol vs accelerometer input prop.

This leads to wrong timestamping ioctl, which leads to crashes.

Change-Id: I31b1629111d4f13057184ccd3966a18f65da4e79