### PR TITLE
REThreaded: Use gen- and delete- textures on all render engines

### DIFF
--- a/libs/renderengine/threaded/RenderEngineThreaded.cpp
+++ b/libs/renderengine/threaded/RenderEngineThreaded.cpp
@@ -178,10 +178,6 @@ void RenderEngineThreaded::dump(std::string& result) {
 
 void RenderEngineThreaded::genTextures(size_t count, uint32_t* names) {
     ATRACE_CALL();
-    // This is a no-op in SkiaRenderEngine.
-    if (getRenderEngineType() != RenderEngineType::THREADED) {
-        return;
-    }
     std::promise<void> resultPromise;
     std::future<void> resultFuture = resultPromise.get_future();
     {
@@ -198,10 +194,6 @@ void RenderEngineThreaded::genTextures(size_t count, uint32_t* names) {
 
 void RenderEngineThreaded::deleteTextures(size_t count, uint32_t const* names) {
     ATRACE_CALL();
-    // This is a no-op in SkiaRenderEngine.
-    if (getRenderEngineType() != RenderEngineType::THREADED) {
-        return;
-    }
     std::promise<void> resultPromise;
     std::future<void> resultFuture = resultPromise.get_future();
     {


### PR DESCRIPTION
* Fixes bootanimation lags.

This reverts commit https://github.com/begonia-dev/android_frameworks_native/commit/48b5f3cbeae031324406ccbcb037651c66611adb.