### PR TITLE
SF: Enable expensive rendering for blurs

### DIFF
--- a/services/surfaceflinger/CompositionEngine/src/Output.cpp
+++ b/services/surfaceflinger/CompositionEngine/src/Output.cpp
@@ -1313,7 +1313,7 @@ std::optional<base::unique_fd> Output::composeSurfaces(
     // or complex GPU shaders and it's expensive. We boost the GPU frequency so that
     // GPU composition can finish in time. We must reset GPU frequency afterwards,
     // because high frequency consumes extra battery.
-    const bool expensiveRenderingExpected =
+    const bool expensiveRenderingExpected = mLayerRequestingBackgroundBlur != nullptr ||
             std::any_of(clientCompositionLayers.begin(), clientCompositionLayers.end(),
                         [outputDataspace =
                                  clientCompositionDisplay.outputDataspace](const auto& layer) {


### PR DESCRIPTION
This was removed in 14, however nothing has changed that makes blur not require expensive rendering hints.

Change-Id: I7893f240fbd1a20223ebce8d35e7a7a30e6392e2