### PR TITLE
Add dalvik-heap device configs for 8/12/16 GiB devices

### DIFF
--- a/build/phone-xhdpi-12288-dalvik-heap.mk
+++ b/build/phone-xhdpi-12288-dalvik-heap.mk
@@ -1,0 +1,26 @@
+#
+# Copyright 2019 The Android Open Source Project
+# Copyright 2019 The halogenOS Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Provides overrides to configure the Dalvik heap for a 12 GiB phone
+
+PRODUCT_PROPERTY_OVERRIDES += \
+    dalvik.vm.heapstartsize=24m \
+    dalvik.vm.heapgrowthlimit=384m \
+    dalvik.vm.heapsize=512m \
+    dalvik.vm.heaptargetutilization=0.42 \
+    dalvik.vm.heapminfree=8m \
+    dalvik.vm.heapmaxfree=56m

--- a/build/phone-xhdpi-16384-dalvik-heap.mk
+++ b/build/phone-xhdpi-16384-dalvik-heap.mk
@@ -1,0 +1,26 @@
+#
+# Copyright 2019 The Android Open Source Project
+# Copyright 2019 The halogenOS Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Provides overrides to configure the Dalvik heap for a 16 GiB phone
+
+PRODUCT_PROPERTY_OVERRIDES += \
+    dalvik.vm.heapstartsize=32m \
+    dalvik.vm.heapgrowthlimit=448m \
+    dalvik.vm.heapsize=640m \
+    dalvik.vm.heaptargetutilization=0.4 \
+    dalvik.vm.heapminfree=16m \
+    dalvik.vm.heapmaxfree=64m

--- a/build/phone-xhdpi-8192-dalvik-heap.mk
+++ b/build/phone-xhdpi-8192-dalvik-heap.mk
@@ -1,0 +1,26 @@
+#
+# Copyright 2019 The Android Open Source Project
+# Copyright 2019 The halogenOS Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Provides overrides to configure the Dalvik heap for a 8 GiB phone
+
+PRODUCT_PROPERTY_OVERRIDES += \
+    dalvik.vm.heapstartsize=24m \
+    dalvik.vm.heapgrowthlimit=256m \
+    dalvik.vm.heapsize=512m \
+    dalvik.vm.heaptargetutilization=0.46 \
+    dalvik.vm.heapminfree=8m \
+    dalvik.vm.heapmaxfree=48m


### PR DESCRIPTION
Test: manual on cheeseburger with 8192 config
Change-Id: Icdfd3512a79d9935d3fdb611c96dc8fd91a5e1c5